### PR TITLE
Solution to GW degradation ** merge before renaming **

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .gradle
 **/build/
 !src/**/build/
+lib/gradle.properties

--- a/app/src/main/kotlin/GridWorld/GridworldState.kt
+++ b/app/src/main/kotlin/GridWorld/GridworldState.kt
@@ -1,24 +1,7 @@
 package GridWorld
 
 class GridworldState(x: Int, y: Int, val isTerminal: Boolean) : GridworldPosition(x, y) {
-    fun isNeighbourValid(action: GridworldAction, xSize: Int, ySize: Int) : Boolean {
-        return when (action) {
-            GridworldAction.UP -> {
-                y != ySize - 1
-            }
-            GridworldAction.RIGHT -> {
-                x == xSize - 1
-            }
-            GridworldAction.DOWN -> {
-                y == 0
-            }
-            GridworldAction.LEFT -> {
-                x == 0
-            }
-        }
-    }
-
-    fun resolveNeighbour(action: GridworldAction, xSize: Int, ySize: Int) : GridworldState? {
+    fun ResolveNeighbour(action: GridworldAction, xSize: Int, ySize: Int) : GridworldState? {
         return when (action) {
             GridworldAction.UP -> {
                 if (y == ySize - 1)  null else GridworldState(x, y + 1, false)

--- a/app/src/test/kotlin/Game2048Tests.kt
+++ b/app/src/test/kotlin/Game2048Tests.kt
@@ -4,7 +4,7 @@ import ExtendedStatelessSolver
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import kotlin.random.Random
-import StatelessSolver
+import ca.aqtech.mctreesearch4j.StatelessSolver
 import kotlin.test.assertNotNull
 
 class Game2048Tests {

--- a/lib/compile_script.sh
+++ b/lib/compile_script.sh
@@ -1,2 +1,2 @@
 gradle clean build;
-cp build/libs/mctreesearch4j-1.0.0-beta.jar ../app/libs/mctreesearch4j-1.0.0-beta.jar
+cp build/libs/mctreesearch4j-0.0.1.jar ../app/libs/mctreesearch4j-0.0.1.jar

--- a/lib/gradle.properties
+++ b/lib/gradle.properties
@@ -1,2 +1,0 @@
-kotlin.code.style=official
-


### PR DESCRIPTION
As a bandaid solution to https://github.com/JunTaoLuo/mctreesearch4j/issues/38, I reverted the changes on `GridworldState.kt` and `GridworldMDP.kt`.

@JunTaoLuo if you identify the issue that caused the degradation, we can narrow in a patch and not be reduced to complete reversion.

We need to get this resolved before we re-namespace the code.